### PR TITLE
Always update sensitive variables before a Run

### DIFF
--- a/operator/pkg/controller/workspace/workspace_controller.go
+++ b/operator/pkg/controller/workspace/workspace_controller.go
@@ -238,6 +238,12 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcile.Res
 
 	if updatedTerraform || updatedVariables || instance.Status.RunID == "" {
 		r.reqLogger.Info("Starting run because template changed", "Organization", organization, "Name", workspace, "Namespace", request.Namespace)
+
+		if err := r.tfclient.UpdateSensitiveBeforeRun(workspace, specTFCVariables); err != nil {
+			r.reqLogger.Error(err, "Could not update Sensitive Varaibles before Run")
+			return reconcile.Result{}, err
+		}
+
 		if err := r.tfclient.CreateRun(instance, terraform); err != nil {
 			r.reqLogger.Error(err, "Could not run new Terraform configuration")
 			return reconcile.Result{}, err


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #22 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-k8s/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Always update Sensitive variables when a Run is triggered and before the Run is executed
```

