### PR TITLE
Non-string variables

### DIFF
--- a/operator/deploy/crds/app.terraform.io_workspaces_crd.yaml
+++ b/operator/deploy/crds/app.terraform.io_workspaces_crd.yaml
@@ -19,12 +19,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -71,6 +71,9 @@ spec:
                     description: EnvironmentVariable denotes if this variable should
                       be created as environment variable
                     type: boolean
+                  hcl:
+                    description: String input should be an HCL-formatted variable
+                    type: boolean
                   key:
                     description: Variable name
                     type: string
@@ -96,7 +99,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the ConfigMap or it's key
+                            description: Specify whether the ConfigMap or its key
                               must be defined
                             type: boolean
                         required:
@@ -150,7 +153,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the Secret or it's key must
+                            description: Specify whether the Secret or its key must
                               be defined
                             type: boolean
                         required:

--- a/operator/pkg/apis/app/v1alpha1/workspace_types.go
+++ b/operator/pkg/apis/app/v1alpha1/workspace_types.go
@@ -47,6 +47,9 @@ type Variable struct {
 	// Source for the variable's value. Cannot be used if value is not empty.
 	// +optional
 	ValueFrom *corev1.EnvVarSource `json:"valueFrom,omitempty"`
+	// String input should be an HCL-formatted variable
+	// +optional
+	HCL bool `json:"hcl"`
 	// Variable is a secret and should be retrieved from file
 	Sensitive bool `json:"sensitive"`
 	// EnvironmentVariable denotes if this variable should be created as environment variable

--- a/operator/pkg/apis/app/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/app/v1alpha1/zz_generated.deepcopy.go
@@ -110,7 +110,7 @@ func (in *Workspace) DeepCopyObject() runtime.Object {
 func (in *WorkspaceList) DeepCopyInto(out *WorkspaceList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.ListMeta = in.ListMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]Workspace, len(*in))

--- a/operator/pkg/controller/workspace/tfc_variable.go
+++ b/operator/pkg/controller/workspace/tfc_variable.go
@@ -23,6 +23,13 @@ func setVariableType(isEnvironmentVariable bool) tfc.CategoryType {
 	return tfc.CategoryTerraform
 }
 
+func setHCL(isHCL bool) bool {
+	if isHCL {
+		return true
+	}
+	return false
+}
+
 // MapToTFCVariable changes the controller spec to a TFC Variable
 func MapToTFCVariable(specVariables []*v1alpha1.Variable) []*tfc.Variable {
 	tfcVariables := []*tfc.Variable{}
@@ -32,6 +39,7 @@ func MapToTFCVariable(specVariables []*v1alpha1.Variable) []*tfc.Variable {
 			Value:     strings.TrimSuffix(variable.Value, "\n"),
 			Sensitive: variable.Sensitive,
 			Category:  setVariableType(variable.EnvironmentVariable),
+			HCL:       setHCL(variable.HCL),
 		})
 	}
 	return tfcVariables
@@ -167,6 +175,7 @@ func (t *TerraformCloudClient) CreateTerraformVariable(workspace *tfc.Workspace,
 		Value:     &variable.Value,
 		Category:  &variable.Category,
 		Sensitive: &variable.Sensitive,
+		HCL:       &variable.HCL,
 		Workspace: workspace,
 	}
 	_, err := t.Client.Variables.Create(context.TODO(), options)


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #11 

Adds the [`HCL` type value](https://www.terraform.io/docs/cloud/workspaces/variables.html#hcl-values) in the CRD in order to support non-string variables for Terraform Cloud.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-k8s/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Enable non-string Terraform variables by setting HCL type (#11 )
```

Output:
<!--
Replace with relevant outputs or interfaces
-->

Example of Workspace custom resource declaration:

```yaml
   # Defaults to HCL=false, therefore string
    - key: environment
      value: preprod
      sensitive: false
      environmentVariable: false
   # Explicitly set to HCL=true, therefore pass as HCL type to Terraform Cloud
    - key: some_list
      value: '["hello","queues"]'
      hcl: true
      sensitive: false
      environmentVariable: false
    - key: some_object
      value: '{hello={name= "test"}}'
      hcl: true
      sensitive: false
      environmentVariable: false
```
