### PR TITLE
Add github actions for triage

### DIFF
--- a/.github/workflows/add_new_issues_to_project.yml
+++ b/.github/workflows/add_new_issues_to_project.yml
@@ -1,0 +1,23 @@
+name: Automate labeled issues
+on:
+  issues:
+    types: [labeled]
+jobs:
+  Move_Bug_To_Triage_Board:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: aareet/move-labeled-or-milestoned-issue@v2.0
+      with:
+        action-token: "${{ secrets.k8s_github_actions }}"
+        project-url: "https://github.com/orgs/terraform-providers/projects/19"
+        column-name: "Needs triage"
+        label-name: "bug"
+  Move_Feature_Request_To_Triage_Board:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: aareet/move-labeled-or-milestoned-issue@v2.0
+      with:
+        action-token: "${{ secrets.k8s_github_actions }}"
+        project-url: "https://github.com/orgs/terraform-providers/projects/19"
+        column-name: "Needs triage"
+        label-name: "enhancement"

--- a/operator/pkg/controller/workspace/workspace_controller.go
+++ b/operator/pkg/controller/workspace/workspace_controller.go
@@ -24,11 +24,6 @@ var log = logf.Log.WithName(TerraformOperator)
 
 const workspaceFinalizer = "finalizer.workspace.app.terraform.io"
 
-/**
-* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
-* business logic.  Delete these comments after modifying this file.*
- */
-
 // Add creates a new Workspace Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

Adds some experimental github actions to allow us to triage new requests.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates or Closes #00000000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-k8s/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output:
<!--
Replace with relevant outputs or interfaces
-->
```
$ kubectl describe workspace
```
