### PR TITLE
Allow users to specify an SSHKey from their Terraform Cloud Organization.

### DIFF
--- a/operator/deploy/crds/app.terraform.io_v1alpha1_workspace_cr.yaml
+++ b/operator/deploy/crds/app.terraform.io_v1alpha1_workspace_cr.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   organization: hashicorp-team-demo
   secretsMountPath: "/tmp/secrets"
+  #sshKeyID: "sshkey-12345"
   module:
     source: "joatmon08/hello/random"
     version: "4.0.0"

--- a/operator/deploy/crds/app.terraform.io_workspaces_crd.yaml
+++ b/operator/deploy/crds/app.terraform.io_workspaces_crd.yaml
@@ -170,6 +170,8 @@ spec:
           - module
           - organization
           - secretsMountPath
+          type: object
+    optional:
           - sshKeyID
           type: object
         status:

--- a/operator/deploy/crds/app.terraform.io_workspaces_crd.yaml
+++ b/operator/deploy/crds/app.terraform.io_workspaces_crd.yaml
@@ -171,9 +171,6 @@ spec:
           - organization
           - secretsMountPath
           type: object
-    optional:
-          - sshKeyID
-          type: object
         status:
           description: WorkspaceStatus defines the observed state of Workspace
           properties:

--- a/operator/deploy/crds/app.terraform.io_workspaces_crd.yaml
+++ b/operator/deploy/crds/app.terraform.io_workspaces_crd.yaml
@@ -19,12 +19,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -62,6 +62,9 @@ spec:
             secretsMountPath:
               description: File path within operator pod to load workspace secrets
               type: string
+            sshKeyID:
+              description: SSH Key ID
+              type: string
             variables:
               description: Variables as inputs to module
               items:
@@ -96,7 +99,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the ConfigMap or it's key
+                            description: Specify whether the ConfigMap or its key
                               must be defined
                             type: boolean
                         required:
@@ -150,7 +153,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the Secret or it's key must
+                            description: Specify whether the Secret or its key must
                               be defined
                             type: boolean
                         required:
@@ -167,6 +170,7 @@ spec:
           - module
           - organization
           - secretsMountPath
+          - sshKeyID
           type: object
         status:
           description: WorkspaceStatus defines the observed state of Workspace

--- a/operator/pkg/apis/app/v1alpha1/workspace_types.go
+++ b/operator/pkg/apis/app/v1alpha1/workspace_types.go
@@ -70,6 +70,9 @@ type WorkspaceSpec struct {
 	// +listType=set
 	// +optional
 	Outputs []*OutputSpec `json:"outputs,omitempty"`
+	// SSH Key ID
+	SSHKeyID string `json:"sshKeyID"`
+	// +optional
 }
 
 // WorkspaceStatus defines the observed state of Workspace

--- a/operator/pkg/apis/app/v1alpha1/workspace_types.go
+++ b/operator/pkg/apis/app/v1alpha1/workspace_types.go
@@ -66,13 +66,13 @@ type WorkspaceSpec struct {
 	Variables []*Variable `json:"variables,omitempty"`
 	// File path within operator pod to load workspace secrets
 	SecretsMountPath string `json:"secretsMountPath"`
+	// SSH Key ID
+	// +optional
+	SSHKeyID string `json:"sshKeyID,omitempty"`
 	// Outputs denote outputs wanted
 	// +listType=set
 	// +optional
 	Outputs []*OutputSpec `json:"outputs,omitempty"`
-	// SSH Key ID
-	SSHKeyID string `json:"sshKeyID"`
-	// +optional
 }
 
 // WorkspaceStatus defines the observed state of Workspace

--- a/operator/pkg/controller/workspace/workspace_controller.go
+++ b/operator/pkg/controller/workspace/workspace_controller.go
@@ -125,7 +125,7 @@ func (r *ReconcileWorkspace) Reconcile(request reconcile.Request) (reconcile.Res
 		return reconcile.Result{}, nil
 	}
 
-	workspaceID, err := r.tfclient.CheckWorkspace(workspace)
+	workspaceID, err := r.tfclient.CheckWorkspace(workspace, instance)
 	if err != nil {
 		r.reqLogger.Error(err, "Could not update workspace")
 		return reconcile.Result{}, err


### PR DESCRIPTION


Relates: #25

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates or Closes #00000000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-k8s/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add `sshKeyID` to the spec.  This causes the workspace to be created (or updated) with the referenced key from the users Terraform Cloud Organization.  This allows users to reference modules in private git repos.
```

Output:
<!--
Replace with relevant outputs or interfaces
-->
```
$ kubectl describe workspace
Name:         hello
Namespace:    default
Labels:       <none>
Annotations:  kubectl.kubernetes.io/last-applied-configuration:
                {"apiVersion":"app.terraform.io/v1alpha1","kind":"Workspace","metadata":{"annotations":{},"name":"hello","namespace":"default"},"spec":{"m...
API Version:  app.terraform.io/v1alpha1
Kind:         Workspace
Metadata:
  Creation Timestamp:  2020-04-16T00:46:13Z
  Finalizers:
    finalizer.workspace.app.terraform.io
  Generation:        5
  Resource Version:  22650
  Self Link:         /apis/app.terraform.io/v1alpha1/namespaces/default/workspaces/hello
  UID:               6aedfa2a-caf3-4c1c-9ca7-0797d0cc9f22
Spec:
  Module:
    Source:      joatmon08/hello/random
    Version:     4.0.0
  Organization:  rojopolis
  Outputs:
    Key:                 my_pets
    Module Output Name:  list_of_pets
  Secrets Mount Path:    /tmp/secrets
  Ssh Key ID:            sshkey-D4fmNfDCWAoBJopq
  Variables:
    Environment Variable:  false
    Key:                   hello
    Sensitive:             false
    Value:                 rosario
    Environment Variable:  false
    Key:                   second_hello
    Sensitive:             false
    Value From:
      Config Map Key Ref:
        Key:               to
        Name:              say-hello
    Environment Variable:  false
    Key:                   secret_key
    Sensitive:             true
    Environment Variable:  true
    Key:                   AWS_SECRET_ACCESS_KEY
    Sensitive:             true
    Environment Variable:  true
    Key:                   CONFIRM_DESTROY
    Sensitive:             false
    Value:                 1
Status:
  Outputs:
    Key:         my_pets
    Value:       ["wondrous-chicken","stable-firefly"]
  Run ID:        run-VcSQEVsphX6qe1i6
  Run Status:    applied
  Workspace ID:  ws-fZ1KJ53xGNExzp3q
Events:          <none>

```
