### PR TITLE
feat(operator): Allow users to specify custom providers

### DIFF
--- a/operator/deploy/crds/app.terraform.io_v1alpha1_workspace_cr.yaml
+++ b/operator/deploy/crds/app.terraform.io_v1alpha1_workspace_cr.yaml
@@ -40,3 +40,8 @@ spec:
       value: "1"
       sensitive: false
       environmentVariable: true
+  additionalProviders:
+  - name: "confluentcloud"
+    source: "https://github.com/parkside-securities/terraform-provider-confluentcloud/releases/download/v.0.0.2/terraform-provider-confluentcloud-v0.0.2-linux-amd64.tar.gz"
+  - name: "kafka"
+    source: "https://github.com/Mongey/terraform-provider-kafka/releases/download/v0.2.4/terraform-provider-kafka_0.2.4_linux_amd64.tar.gz?checksum=file:https://github.com/Mongey/terraform-provider-kafka/releases/download/v0.2.4/checksums.txt"

--- a/operator/deploy/crds/app.terraform.io_workspaces_crd.yaml
+++ b/operator/deploy/crds/app.terraform.io_workspaces_crd.yaml
@@ -19,18 +19,33 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
           description: WorkspaceSpec defines the desired state of Workspace
           properties:
+            additionalProviders:
+              description: AdditionalProviders
+              items:
+                properties:
+                  name:
+                    description: Name
+                    type: string
+                  source:
+                    description: Source Path of provider in go-getter syntax
+                    type: string
+                required:
+                - name
+                - source
+                type: object
+              type: array
             module:
               description: Module source and version to use
               properties:
@@ -96,7 +111,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the ConfigMap or it's key
+                            description: Specify whether the ConfigMap or its key
                               must be defined
                             type: boolean
                         required:
@@ -150,7 +165,7 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the Secret or it's key must
+                            description: Specify whether the Secret or its key must
                               be defined
                             type: boolean
                         required:

--- a/operator/pkg/apis/app/v1alpha1/workspace_types.go
+++ b/operator/pkg/apis/app/v1alpha1/workspace_types.go
@@ -53,6 +53,13 @@ type Variable struct {
 	EnvironmentVariable bool `json:"environmentVariable"`
 }
 
+type Provider struct {
+	// Name
+	Name string `json:"name"`
+	// Source Path of provider in go-getter syntax
+	Source string `json:"source"`
+}
+
 // WorkspaceSpec defines the desired state of Workspace
 // +k8s:openapi-gen=true
 type WorkspaceSpec struct {
@@ -70,6 +77,10 @@ type WorkspaceSpec struct {
 	// +listType=set
 	// +optional
 	Outputs []*OutputSpec `json:"outputs,omitempty"`
+	// AdditionalProviders
+	// +listType=set
+	// +optional
+	AdditionalProviders []*Provider `json:"additionalProviders,omitempty"`
 }
 
 // WorkspaceStatus defines the observed state of Workspace


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #21

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-k8s/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Allow users to specify custom providers to include in the generated Configuration Version.  Additional providers are specified as part of the Workspace spec.  The Source argument is expected to be a properly formed go-getter URL that points to a linux-amd64 compiled binary, or archive.
```

$ kubectl describe workspace
```yaml
Name:         bucket
Namespace:    default
Labels:       <none>
Annotations:  API Version:  app.terraform.io/v1alpha1
Kind:         Workspace
Metadata:
  Creation Timestamp:  2020-04-21T23:47:51Z
  Finalizers:
    finalizer.workspace.app.terraform.io
  Generation:        2
  Resource Version:  17006
  Self Link:         /apis/app.terraform.io/v1alpha1/namespaces/default/workspaces/bucket
  UID:               6b0f508a-202a-4288-bc07-011641d50a10
Spec:
  Additional Providers:
    Name:    confluentcloud
    Source:  https://github.com/parkside-securities/terraform-provider-confluentcloud/releases/download/v.0.0.2/terraform-provider-confluentcloud-v0.0.2-linux-amd64.tar.gz
    Name:    kafka
    Source:  https://github.com/Mongey/terraform-provider-kafka/releases/download/v0.2.4/terraform-provider-kafka_0.2.4_linux_amd64.tar.gz?checksum=file:https://github.com/Mongey/terraform-provider-kafka/releases/download/v0.2.4/checksums.txt
  Module:
    Source:            github.com/rojopolis/terraform-aws-s3-bucket.git
    Version:           
  Organization:        rojo-test
  Secrets Mount Path:  /tmp/secrets
  Variables:
    Environment Variable:  false
    Key:                   bucket
    Sensitive:             false
    Value:                 entertainment-720-3399
    Environment Variable:  true
    Key:                   AWS_DEFAULT_REGION
    Sensitive:             false
    Value:                 us-west-2
    Environment Variable:  true
    Key:                   AWS_ACCESS_KEY_ID
    Sensitive:             true
    Value:                 
    Value From:
      Secret Key Ref:
        Key:               AWS_ACCESS_KEY_ID
        Name:              workspacesecrets
    Environment Variable:  true
    Key:                   AWS_SECRET_ACCESS_KEY
    Sensitive:             true
    Value:                 
    Value From:
      Secret Key Ref:
        Key:               AWS_SECRET_ACCESS_KEY
        Name:              workspacesecrets
    Environment Variable:  true
    Key:                   CONFLUENT_CLOUD_USERNAME
    Sensitive:             false
    Value:                 billing@parksidesecurities.com
    Environment Variable:  true
    Key:                   CONFLUENT_CLOUD_PASSWORD
    Sensitive:             true
    Value:                 
    Value From:
      Secret Key Ref:
        Key:               CONFLUENT_CLOUD_PASSWORD
        Name:              workspacesecrets
    Environment Variable:  true
    Key:                   CONFIRM_DESTROY
    Sensitive:             false
    Value:                 1
Status:
  Run ID:        run-DRtUKkqY8aCPizXc
  Run Status:    applied
  Workspace ID:  ws-GXFKBV3TR5zGf2dF
Events:          <none>
```
