### PR TITLE
feat(sshKey): Allow SSH Keys to be specified by name or ID

### DIFF
--- a/operator/deploy/crds/app.terraform.io_workspaces_crd.yaml
+++ b/operator/deploy/crds/app.terraform.io_workspaces_crd.yaml
@@ -63,7 +63,9 @@ spec:
               description: File path within operator pod to load workspace secrets
               type: string
             sshKeyID:
-              description: SSH Key ID
+              description: SSH Key ID. This key must already exist in the TF Cloud
+                orgaization.  This can either be the user assigned name of the SSH
+                Key, or the system assigned ID.
               type: string
             variables:
               description: Variables as inputs to module

--- a/operator/deploy/crds/app.terraform.io_workspaces_crd.yaml
+++ b/operator/deploy/crds/app.terraform.io_workspaces_crd.yaml
@@ -64,7 +64,7 @@ spec:
               type: string
             sshKeyID:
               description: SSH Key ID. This key must already exist in the TF Cloud
-                orgaization.  This can either be the user assigned name of the SSH
+                organization.  This can either be the user assigned name of the SSH
                 Key, or the system assigned ID.
               type: string
             variables:

--- a/operator/pkg/apis/app/v1alpha1/workspace_types.go
+++ b/operator/pkg/apis/app/v1alpha1/workspace_types.go
@@ -69,7 +69,7 @@ type WorkspaceSpec struct {
 	Variables []*Variable `json:"variables,omitempty"`
 	// File path within operator pod to load workspace secrets
 	SecretsMountPath string `json:"secretsMountPath"`
-	// SSH Key ID. This key must already exist in the TF Cloud orgaization.  This can either be the user assigned name of the SSH Key, or the system assigned ID.
+	// SSH Key ID. This key must already exist in the TF Cloud organization.  This can either be the user assigned name of the SSH Key, or the system assigned ID.
 	// +optional
 	SSHKeyID string `json:"sshKeyID,omitempty"`
 	// Outputs denote outputs wanted

--- a/operator/pkg/apis/app/v1alpha1/workspace_types.go
+++ b/operator/pkg/apis/app/v1alpha1/workspace_types.go
@@ -69,7 +69,7 @@ type WorkspaceSpec struct {
 	Variables []*Variable `json:"variables,omitempty"`
 	// File path within operator pod to load workspace secrets
 	SecretsMountPath string `json:"secretsMountPath"`
-	// SSH Key ID
+	// SSH Key ID. This key must already exist in the TF Cloud orgaization.  This can either be the user assigned name of the SSH Key, or the system assigned ID.
 	// +optional
 	SSHKeyID string `json:"sshKeyID,omitempty"`
 	// Outputs denote outputs wanted


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #41

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-k8s/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Allow user to specify SSH Key by name or ID.
```

$ kubectl describe workspace

```yaml
Name:         hello
Namespace:    default
Labels:       <none>
Annotations:  kubectl.kubernetes.io/last-applied-configuration:
                {"apiVersion":"app.terraform.io/v1alpha1","kind":"Workspace","metadata":{"annotations":{},"name":"hello","namespace":"default"},"spec":{"m...
API Version:  app.terraform.io/v1alpha1
Kind:         Workspace
Metadata:
  Creation Timestamp:  2020-04-28T23:27:54Z
  Finalizers:
    finalizer.workspace.app.terraform.io
  Generation:        2
  Resource Version:  3928
  Self Link:         /apis/app.terraform.io/v1alpha1/namespaces/default/workspaces/hello
  UID:               3928c305-4e65-4d16-a880-6abbe06e2e24
Spec:
  Module:
    Source:      joatmon08/hello/random
    Version:     4.0.0
  Organization:  rojopolis
  Outputs:
    Key:                 my_pets
    Module Output Name:  list_of_pets
  Secrets Mount Path:    /tmp/secrets
  Ssh Key ID:            my-key
  Variables:
    Environment Variable:  false
    Hcl:                   false
    Key:                   hello
    Sensitive:             false
    Value:                 rosemary
    Environment Variable:  false
    Hcl:                   false
    Key:                   second_hello
    Sensitive:             false
    Value:                 
    Value From:
      Config Map Key Ref:
        Key:               to
        Name:              say-hello
    Environment Variable:  false
    Hcl:                   false
    Key:                   secret_key
    Sensitive:             true
    Value:                 
    Environment Variable:  true
    Hcl:                   false
    Key:                   AWS_SECRET_ACCESS_KEY
    Sensitive:             true
    Value:                 
    Environment Variable:  true
    Hcl:                   false
    Key:                   CONFIRM_DESTROY
    Sensitive:             false
    Value:                 1
Status:
  Run ID:        run-iq8FCeULw8UrnHcJ
  Run Status:    plan_queued
  Workspace ID:  ws-rpYsJDgEc1hrNY1e
Events:          <none>
```