### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,17 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.8
+        go-version: 1.15.5
+    - name: Install kubebuilder
+      run: |
+        curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_amd64.tar.gz -o /tmp/kb.tgz
+        tar zxf /tmp/kb.tgz -C /tmp/
     - name: Run GoReleaser
+      env:
+        KUBEBUILDER_ASSETS: /tmp/kubebuilder_2.3.1_linux_amd64/bin/
       uses: goreleaser/goreleaser-action@v1.3.1
       with:
         args: release --skip-sign
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-        


### PR DESCRIPTION
The kubebuilder assets are required for the tests to pass since we
upgraded the version of the operator SDK.

