### PR TITLE
Add support for outputName, outputNamespace overrides.

### DIFF
--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -126,6 +126,12 @@ type WorkspaceSpec struct {
 	// SSH Key ID. This key must already exist in the TF Cloud organization.  This can either be the user assigned name of the SSH Key, or the system assigned ID.
 	// +optional
 	SSHKeyID string `json:"sshKeyID,omitempty"`
+	// Overrides default output name. Default output name is `<workspaceName>-outputs`.
+	// +optional
+	OutputName string `json:"outputName,omitempty"`
+	// Overrides default output namespace. Default namespace is the same namespace as the workspace.
+	// +optional
+	OutputNamespace string `json:"outputNamespace,omitempty"`
 	// Outputs denote outputs wanted
 	// +optional
 	Outputs []*OutputSpec `json:"outputs,omitempty"`
@@ -157,6 +163,14 @@ type WorkspaceStatus struct {
 	RunID string `json:"runID"`
 	// Configuration Version ID
 	ConfigVersionID string `json:"configVersionID"`
+	// Current output name
+	// +optional
+	// +nullable
+	OutputName string `json:"outputName"`
+	// Current output namespace
+	// +optional
+	// +nullable
+	OutputNamespace string `json:"outputNamespace"`
 	// Outputs from state file
 	// +optional
 	Outputs []*OutputStatus `json:"outputs,omitempty"`

--- a/config/crd/bases/app.terraform.io_workspaces.yaml
+++ b/config/crd/bases/app.terraform.io_workspaces.yaml
@@ -104,6 +104,12 @@ spec:
             organization:
               description: Terraform Cloud organization
               type: string
+            outputName:
+              description: Overrides default output name. Default output name is <workspaceName>-outputs.
+              type: string
+            outputNamespace:
+              description: Overrides default output namespace. Default namespace is the same namespace as the workspace.
+              type: string
             outputs:
               description: Outputs denote outputs wanted
               items:


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #110 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-k8s/blob/master/CHANGELOG.md):

```release-note
- Adds support for `outputName` and `outputNamespace`
```

Output:
<!--
Replace with relevant outputs or interfaces
-->
```
---
apiVersion: app.terraform.io/v1alpha1
kind: Workspace
metadata:
  name: test-workspace
  namespace: terraform
spec:
  module:
    source: app.terraform.io/some_org/some_module/some_provider
    version: 1.0.0
  organization: some_org
  outputNamespace: my_namespace
  outputName: my_secret
  outputs:
  - key: some_output
    moduleOutputName: some_output
  secretsMountPath: /tmp/secrets
  variables:
  - key: some_key
    value: some_value
    sensitive: false
    environmentVariable: false
```

The above would create secret `my_secret` in the `my_namespace` namespace.