### PR TITLE
Fixing convnersion of null value

### DIFF
--- a/workspacehelper/tfc_output.go
+++ b/workspacehelper/tfc_output.go
@@ -24,7 +24,7 @@ func (t *TerraformCloudClient) GetStateVersionDownloadURL(workspaceID string) (s
 
 func convertValueToString(val cty.Value) string {
 	if val.IsNull() {
-		return ""
+		return "null"
 	}
 	ty := val.Type()
 	switch {
@@ -76,17 +76,19 @@ func convertValueToString(val cty.Value) string {
 		var b bytes.Buffer
 
 		i := 0
+		valLen := val.LengthInt()
 		for it := val.ElementIterator(); it.Next(); {
 			key, value := it.Element()
 			k := convertValueToString(key)
 			v := convertValueToString(value)
 			if k == "" || v == "" {
+				valLen--
 				continue
 			}
 			b.WriteString(k)
 			b.WriteString(":")
 			b.WriteString(v)
-			if i < (val.LengthInt() - 1) {
+			if i < (valLen - 1) {
 				b.WriteString(",")
 			}
 			i++
@@ -109,19 +111,20 @@ func convertValueToString(val cty.Value) string {
 
 		var b bytes.Buffer
 		i := 0
+		atysLen := len(atys)
 		for _, attr := range attrNames {
 			val := val.GetAttr(attr)
 			v := convertValueToString(val)
 			if v == "" {
+				atysLen--
 				continue
 			}
-
 			b.WriteString(`"`)
 			b.WriteString(attr)
 			b.WriteString(`"`)
 			b.WriteString(":")
 			b.WriteString(v)
-			if i < (len(atys) - 1) {
+			if i < (atysLen - 1) {
 				b.WriteString(",")
 			}
 			i++

--- a/workspacehelper/tfc_output_test.go
+++ b/workspacehelper/tfc_output_test.go
@@ -70,7 +70,7 @@ func TestShouldReturnStringFromObject(t *testing.T) {
 }
 
 func TestShouldReturnEmptyStringFromNullObject(t *testing.T) {
-	expected := ""
+	expected := "null"
 	value := cty.NullVal(cty.Map(cty.String))
 	formatted := convertValueToString(value)
 	assert.Equal(t, expected, formatted)
@@ -126,7 +126,7 @@ func TestOutputsFromState(t *testing.T) {
           }
       }
   }`,
-			want: []*v1alpha1.OutputStatus{},
+			want: []*v1alpha1.OutputStatus{{Key: "map1", Value: "[{\"null_map\":null}]"}},
 		},
 		{
 			name: "embedded JSON empty array returns no status",


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

---

This PR is fixing handling of outputs that contain `null`. In the current implementation, if an output contains anywhere a value that is `null`, that output key is skipped completely. For example if the output is the result from the `random_password` resource:

```terraform
resource "random_password" "password" {
  length           = 16
  special          = true
  override_special = "!#$%&*()-_=+[]{}<>:?"
}

output "password" {
  description = "Password output"
  value       = random_password.password
  sensitive   = true
}
```

the ` keepers` key is completely missing in the outputs.

```
$ kubectl get secret -o yaml test-outputs | yq e '.data.password' - | base64 -d 
{"id":"none","length":16,"lower":true,"min_lower":0,"min_numeric":0,"min_special":0,"min_upper":0,"number":true,"override_special":"!#$%&*()-_=+[]{}<>:?","result":"Z3i?:ZbQ#RzmPwk<","special":true,"upper":true,}
```

As a consequence of skipping the `keepers` from outputs, there is also an extra `,` at the end of the encoded output.

With this PR applied, the outputs contain the `keepers` and even if it would be skipped, the extra `,` would not be added:

```
$ kubectl get secret -o yaml test-outputs | yq e '.data.password' - | base64 -d 
{"id":"none","keepers":null,"length":16,"lower":true,"min_lower":0,"min_numeric":0,"min_special":0,"min_upper":0,"number":true,"override_special":"!#$%&*()-_=+[]{}<>:?","result":"Z3i?:ZbQ#RzmPwk<","special":true,"upper":true}
```

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-k8s/blob/master/CHANGELOG.md):
```release-note
Fix for handling null values in outputs.
```