### PR TITLE
Support sensitive output (fixes #107)

### DIFF
--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -40,6 +40,9 @@ type OutputSpec struct {
 	// Attribute name in module
 	// +optional
 	ModuleOutputName string `json:"moduleOutputName"`
+	// Sensitive value
+	// +optional
+	Sensitive bool `json:"sensitive,omitempty"`
 }
 
 // OutputStatus outputs the values of Terraform output

--- a/config/crd/bases/app.terraform.io_workspaces.yaml
+++ b/config/crd/bases/app.terraform.io_workspaces.yaml
@@ -119,6 +119,9 @@ spec:
                     moduleOutputName:
                       description: Attribute name in module
                       type: string
+                    sensitive:
+                      description: Sensitive value
+                      type: boolean
                   type: object
                 type: array
               runTriggers:

--- a/config/crd/bases/app.terraform.io_workspaces.yaml
+++ b/config/crd/bases/app.terraform.io_workspaces.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,285 +15,313 @@ spec:
     plural: workspaces
     singular: workspace
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Workspace is the Schema for the workspaces API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: WorkspaceSpec defines the desired state of Workspace
-          properties:
-            agentPoolID:
-              description: Specifies the agent pool ID we wish to use.
-              type: string
-            agentPoolName:
-              description: Specifies the agent pool name we wish to use.
-              type: string
-            module:
-              description: Module source and version to use
-              nullable: true
-              properties:
-                source:
-                  description: Any remote module source (version control, registry)
-                  type: string
-                version:
-                  description: Module version for registry modules
-                  type: string
-              required:
-              - source
-              type: object
-            notifications:
-              description: Notification configuration
-              items:
-                description: Notification notification holds all the necessary information
-                  required to configure any workspace notification
-                properties:
-                  enabled:
-                    description: Control if the notification is enabled or not
-                    type: boolean
-                  name:
-                    description: Name of the hook
-                    type: string
-                  recipients:
-                    description: List of recipients' email addresses. Only applicable
-                      for TFE endpoints.
-                    items:
-                      type: string
-                    type: array
-                  token:
-                    description: Token used to generate an HMAC on the verificatio0n
-                      request
-                    type: string
-                  triggers:
-                    description: When the web hook gets triggered. Acceptable values
-                      are run:created, run:planning, run:needs_attention, run:applying,
-                      run:completed, run:errored.
-                    items:
-                      type: string
-                    type: array
-                  type:
-                    description: Notification type. Can be one of email, generic,
-                      or slack
-                    type: string
-                  url:
-                    description: URL of the hook
-                    type: string
-                  users:
-                    description: List of users to receive the notificaiton email.
-                    items:
-                      type: string
-                    type: array
-                required:
-                - enabled
-                - name
-                - type
-                type: object
-              type: array
-            omitNamespacePrefix:
-              description: Omit namespace prefix in workspace name
-              type: boolean
-            organization:
-              description: Terraform Cloud organization
-              type: string
-            outputs:
-              description: Outputs denote outputs wanted
-              items:
-                description: OutputSpec specifies which values need to be output
-                properties:
-                  key:
-                    description: Output name
-                    type: string
-                  moduleOutputName:
-                    description: Attribute name in module
-                    type: string
-                type: object
-              type: array
-            runTriggers:
-              description: Run Triggers from source workspaces to trigger this workspace
-              items:
-                description: Run Trigger from a source workspace
-                properties:
-                  sourceableName:
-                    description: Name of source workspace that triggers the current
-                      workspace
-                    type: string
-                required:
-                - sourceableName
-                type: object
-              type: array
-            secretsMountPath:
-              description: File path within operator pod to load workspace secrets
-              type: string
-            sshKeyID:
-              description: SSH Key ID. This key must already exist in the TF Cloud organization.  This can either be the user assigned name of the SSH Key, or the system assigned ID.
-              type: string
-            terraformVersion:
-              description: Terraform version used for this workspace. The default is `latest`.
-              type: string
-            variables:
-              description: Variables as inputs to module
-              items:
-                description: Variable denotes an input to the module
-                properties:
-                  environmentVariable:
-                    description: EnvironmentVariable denotes if this variable should be created as environment variable
-                    type: boolean
-                  hcl:
-                    description: String input should be an HCL-formatted variable
-                    type: boolean
-                  key:
-                    description: Variable name
-                    type: string
-                  sensitive:
-                    description: Variable is a secret and should be retrieved from file
-                    type: boolean
-                  value:
-                    description: Variable value
-                    type: string
-                  valueFrom:
-                    description: Source for the variable's value. Cannot be used if value is not empty.
-                    properties:
-                      configMapKeyRef:
-                        description: Selects a key of a ConfigMap.
-                        properties:
-                          key:
-                            description: The key to select.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the ConfigMap or its key must be defined
-                            type: boolean
-                        required:
-                        - key
-                        type: object
-                      fieldRef:
-                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
-                        properties:
-                          apiVersion:
-                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
-                            type: string
-                          fieldPath:
-                            description: Path of the field to select in the specified API version.
-                            type: string
-                        required:
-                        - fieldPath
-                        type: object
-                      resourceFieldRef:
-                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
-                        properties:
-                          containerName:
-                            description: 'Container name: required for volumes, optional for env vars'
-                            type: string
-                          divisor:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: Specifies the output format of the exposed resources, defaults to "1"
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          resource:
-                            description: 'Required: resource to select'
-                            type: string
-                        required:
-                        - resource
-                        type: object
-                      secretKeyRef:
-                        description: Selects a key of a secret in the pod's namespace
-                        properties:
-                          key:
-                            description: The key of the secret to select from.  Must be a valid secret key.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the Secret or its key must be defined
-                            type: boolean
-                        required:
-                        - key
-                        type: object
-                    type: object
-                required:
-                - environmentVariable
-                - key
-                - sensitive
-                type: object
-              type: array
-            vcs:
-              description: Details of the VCS repository we want to connect to the workspace
-              nullable: true
-              properties:
-                branch:
-                  description: The repository branch to use
-                  type: string
-                ingress_submodules:
-                  description: Whether submodules should be fetched when cloning the VCS repository (Defaults to false)
-                  type: boolean
-                repo_identifier:
-                  description: A reference to your VCS repository in the format org/repo
-                  type: string
-                token_id:
-                  description: Token ID of the VCS Connection (OAuth Connection Token) to use https://www.terraform.io/docs/cloud/vcs
-                  type: string
-              required:
-              - repo_identifier
-              - token_id
-              type: object
-          required:
-          - organization
-          - secretsMountPath
-          type: object
-        status:
-          description: WorkspaceStatus defines the observed state of Workspace
-          properties:
-            configVersionID:
-              description: Configuration Version ID
-              type: string
-            outputs:
-              description: Outputs from state file
-              items:
-                description: OutputStatus outputs the values of Terraform output
-                properties:
-                  key:
-                    description: Attribute name in module
-                    type: string
-                  value:
-                    description: Value
-                    type: string
-                type: object
-              type: array
-            runID:
-              description: Run ID
-              type: string
-            runStatus:
-              description: Run Status gets the run status
-              type: string
-            workspaceID:
-              description: Workspace ID
-              type: string
-          required:
-          - configVersionID
-          - runID
-          - runStatus
-          - workspaceID
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Workspace is the Schema for the workspaces API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WorkspaceSpec defines the desired state of Workspace
+            properties:
+              agentPoolID:
+                description: Specifies the agent pool ID we wish to use.
+                type: string
+              agentPoolName:
+                description: Specifies the agent pool name we wish to use.
+                type: string
+              module:
+                description: Module source and version to use
+                nullable: true
+                properties:
+                  source:
+                    description: Any remote module source (version control, registry)
+                    type: string
+                  version:
+                    description: Module version for registry modules
+                    type: string
+                required:
+                - source
+                type: object
+              notifications:
+                description: Notification configuration
+                items:
+                  description: Notification notification holds all the necessary information
+                    required to configure any workspace notification
+                  properties:
+                    enabled:
+                      description: Control if the notification is enabled or not
+                      type: boolean
+                    name:
+                      description: Name of the hook
+                      type: string
+                    recipients:
+                      description: List of recipients' email addresses. Only applicable
+                        for TFE endpoints.
+                      items:
+                        type: string
+                      type: array
+                    token:
+                      description: Token used to generate an HMAC on the verificatio0n
+                        request
+                      type: string
+                    triggers:
+                      description: When the web hook gets triggered. Acceptable values
+                        are run:created, run:planning, run:needs_attention, run:applying,
+                        run:completed, run:errored.
+                      items:
+                        type: string
+                      type: array
+                    type:
+                      description: Notification type. Can be one of email, generic,
+                        or slack
+                      type: string
+                    url:
+                      description: URL of the hook
+                      type: string
+                    users:
+                      description: List of users to receive the notificaiton email.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - enabled
+                  - name
+                  - type
+                  type: object
+                type: array
+              omitNamespacePrefix:
+                description: Omit namespace prefix in workspace name
+                type: boolean
+              organization:
+                description: Terraform Cloud organization
+                type: string
+              outputs:
+                description: Outputs denote outputs wanted
+                items:
+                  description: OutputSpec specifies which values need to be output
+                  properties:
+                    key:
+                      description: Output name
+                      type: string
+                    moduleOutputName:
+                      description: Attribute name in module
+                      type: string
+                  type: object
+                type: array
+              runTriggers:
+                description: Run Triggers from source workspaces to trigger this workspace
+                items:
+                  description: Run Trigger from a source workspace
+                  properties:
+                    sourceableName:
+                      description: Name of source workspace that triggers the current
+                        workspace
+                      type: string
+                  required:
+                  - sourceableName
+                  type: object
+                type: array
+              secretsMountPath:
+                description: File path within operator pod to load workspace secrets
+                type: string
+              sshKeyID:
+                description: SSH Key ID. This key must already exist in the TF Cloud
+                  organization.  This can either be the user assigned name of the
+                  SSH Key, or the system assigned ID.
+                type: string
+              terraformVersion:
+                description: Terraform version used for this workspace. The default
+                  is `latest`.
+                type: string
+              variables:
+                description: Variables as inputs to module
+                items:
+                  description: Variable denotes an input to the module
+                  properties:
+                    environmentVariable:
+                      description: EnvironmentVariable denotes if this variable should
+                        be created as environment variable
+                      type: boolean
+                    hcl:
+                      description: String input should be an HCL-formatted variable
+                      type: boolean
+                    key:
+                      description: Variable name
+                      type: string
+                    sensitive:
+                      description: Variable is a secret and should be retrieved from
+                        file
+                      type: boolean
+                    value:
+                      description: Variable value
+                      type: string
+                    valueFrom:
+                      description: Source for the variable's value. Cannot be used
+                        if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - environmentVariable
+                  - key
+                  - sensitive
+                  type: object
+                type: array
+              vcs:
+                description: Details of the VCS repository we want to connect to the
+                  workspace
+                nullable: true
+                properties:
+                  branch:
+                    description: The repository branch to use
+                    type: string
+                  ingress_submodules:
+                    description: Whether submodules should be fetched when cloning
+                      the VCS repository (Defaults to false)
+                    type: boolean
+                  repo_identifier:
+                    description: A reference to your VCS repository in the format
+                      org/repo
+                    type: string
+                  token_id:
+                    description: Token ID of the VCS Connection (OAuth Connection
+                      Token) to use https://www.terraform.io/docs/cloud/vcs
+                    type: string
+                required:
+                - repo_identifier
+                - token_id
+                type: object
+            required:
+            - organization
+            - secretsMountPath
+            type: object
+          status:
+            description: WorkspaceStatus defines the observed state of Workspace
+            properties:
+              configVersionID:
+                description: Configuration Version ID
+                type: string
+              outputs:
+                description: Outputs from state file
+                items:
+                  description: OutputStatus outputs the values of Terraform output
+                  properties:
+                    key:
+                      description: Attribute name in module
+                      type: string
+                    value:
+                      description: Value
+                      type: string
+                  type: object
+                type: array
+              runID:
+                description: Run ID
+                type: string
+              runStatus:
+                description: Run Status gets the run status
+                type: string
+              workspaceID:
+                description: Workspace ID
+                type: string
+            required:
+            - configVersionID
+            - runID
+            - runStatus
+            - workspaceID
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/workspacehelper/terraform.go
+++ b/workspacehelper/terraform.go
@@ -33,6 +33,7 @@ func CreateTerraformTemplate(workspace *v1alpha1.Workspace) ([]byte, error) {
 	{{- range .Spec.Outputs}}
 	output "{{.Key}}" {
 		value = module.operator.{{.ModuleOutputName}}
+		sensitive = {{.Sensitive}}
 	}
 	{{- end}}
 	module "operator" {

--- a/workspacehelper/terraform_test.go
+++ b/workspacehelper/terraform_test.go
@@ -145,9 +145,15 @@ func TestShouldCreateTerraformWithOutputs(t *testing.T) {
 	}
 	output "module_output" {
 		value = module.operator.my_output
+		sensitive = false
 	}
 	output "ip" {
 		value = module.operator.ip_address
+		sensitive = false
+	}
+	output "password" {
+		value = module.operator.my_password
+		sensitive = true
 	}
 	module "operator" {
 		source = "my_source"
@@ -173,6 +179,11 @@ func TestShouldCreateTerraformWithOutputs(t *testing.T) {
 				{
 					Key:              "ip",
 					ModuleOutputName: "ip_address",
+				},
+				{
+					Key:              "password",
+					ModuleOutputName: "my_password",
+					Sensitive:        true,
 				},
 			},
 		},

--- a/workspacehelper/tfc_output.go
+++ b/workspacehelper/tfc_output.go
@@ -151,14 +151,12 @@ func (t *TerraformCloudClient) GetOutputsFromState(stateDownloadURL string) ([]*
 	outputValues := file.State.Modules[""].OutputValues
 	outputs := []*v1alpha1.OutputStatus{}
 	for key, value := range outputValues {
-		if !value.Sensitive {
-			if err != nil {
-				return outputs, fmt.Errorf("output value could not be converted to string, Error, %v", err)
-			}
-			statusValue := convertValueToString(value.Value)
-			if statusValue != "" {
-				outputs = append(outputs, &v1alpha1.OutputStatus{Key: key, Value: statusValue})
-			}
+		if err != nil {
+			return outputs, fmt.Errorf("output value could not be converted to string, Error, %v", err)
+		}
+		statusValue := convertValueToString(value.Value)
+		if statusValue != "" {
+			outputs = append(outputs, &v1alpha1.OutputStatus{Key: key, Value: statusValue})
 		}
 	}
 	return outputs, nil


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

---

This PR is adding support for sensitive outputs. This closes the issue #107 and requires CRD update from PR #129. The bellow `Workspace` resource been tested with [this](https://github.com/jtyr/terraform-tfco-test) Terraform module.

```yaml
apiVersion: app.terraform.io/v1alpha1
kind: Workspace
metadata:
  name: test
spec:
  module:
    source: app.terraform.io/jtyr/test/tfco
    version: 0.0.4
  organization: jtyr
  outputs:
    - key: string
      moduleOutputName: string
    - key: int
      moduleOutputName: int
    - key: float
      moduleOutputName: float
    - key: bool
      moduleOutputName: bool
    - key: "null"
      moduleOutputName: "null"
    - key: list
      moduleOutputName: list
    - key: map
      moduleOutputName: map
    - key: password
      moduleOutputName: password
      sensitive: true
    - key: sensitive
      moduleOutputName: sensitive
      sensitive: true
  omitNamespacePrefix: true
  secretsMountPath: /tmp/secrets
  variables:
    - key: "null"
      value: null value 1
```

The resulting `test-outputs` secret then contains those outputs:

```
$ kubectl get secret -o yaml test-outputs | yq e '.data' -
bool: dHJ1ZQ==
float: MS4yMw==
int: MTIz
list: WyJmb28iLCJiYXIiXQ==
map: eyJiYXIiOiJ4eXoiLCJmb28iOiJhYmMifQ==
"null": Im51bGwgdmFsdWUgMSI=
password: eyJpZCI6Im5vbmUiLCJrZWVwZXJzIjpudWxsLCJsZW5ndGgiOjE2LCJsb3dlciI6dHJ1ZSwibWluX2xvd2VyIjowLCJtaW5fbnVtZXJpYyI6MCwibWluX3NwZWNpYWwiOjAsIm1pbl91cHBlciI6MCwibnVtYmVyIjp0cnVlLCJvdmVycmlkZV9zcGVjaWFsIjoiISMkJSYqKCktXz0rW117fTw+Oj8iLCJyZXN1bHQiOiJaM2k/OlpiUSNSem1Qd2s8Iiwic3BlY2lhbCI6dHJ1ZSwidXBwZXIiOnRydWV9
sensitive: IlNFTlNJVElWRSBURVNUIg==
string: IkhlbGxvIHdvcmxkIg==
```

As you can see, the `password` and `sensitive` outputs are visible in the resulting secret thanks to the `sensitive: true` set in the `Workspace` resource.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-k8s/blob/master/CHANGELOG.md):
```release-note
Added support for sensitive outputs
```