### PR TITLE
Remove mention of deprecated variable CONFIRM_DESTROY

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,16 +263,6 @@ $ kubectl apply -n $NAMESPACE -f workspace.yml
 
 ### Delete a Workspace
 
-In order for workspace destruction to work automatically, you must set the `CONFIRM_DESTROY` environment variable in the Terraform Cloud workspace. When you delete the Workspace CustomResource, the operator will attempt to destroy the workspace. As a secondary check, you must deploy the operator with this environment variable defined in the `variables` section if you would like to destroy the workspace in Terraform Cloud.
-
-```yaml
-variables:
-  - key: CONFIRM_DESTROY
-    value: "1"
-    sensitive: false
-    environmentVariable: true
-```
-
 When deleting the Workspace CustomResource, the command line will wait for a few moments.
 
 ```shell


### PR DESCRIPTION
This removes mentions of the CONFIRM_DESTROY environment variable as it's been deprecated in TFC and no longer has any effect.
