### PR TITLE
Strings should not contain quotes in outputs

### DIFF
--- a/workspacehelper/tfc_output.go
+++ b/workspacehelper/tfc_output.go
@@ -45,7 +45,7 @@ func convertValueToString(val cty.Value) string {
 					return convertValueToString(jv)
 				}
 			}
-			return `"` + val.AsString() + `"`
+			return val.AsString()
 		case cty.Bool:
 			if val.True() {
 				return "true"


### PR DESCRIPTION
TFE/Cloud output of type string does not contain quotes in TF state.
Operator adds quotes which causes unexpected behavior to consumers
in Kubernetes who should be receiving the same value as it is in the
workspace.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request


Relates or Closes #40 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-k8s/blob/master/CHANGELOG.md):
