### PR TITLE
Adding support for working-directory in CRD for workspace

### DIFF
--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -144,6 +144,9 @@ type WorkspaceSpec struct {
 	// Specifies the agent pool name we wish to use.
 	// +optional
 	AgentPoolName string `json:"agentPoolName,omitempty"`
+	// Working directory within the module repository
+	// +optional
+	WorkingDirectory string `json:"workingDirectory,omitempty"`
 }
 
 // WorkspaceStatus defines the observed state of Workspace

--- a/config/crd/bases/app.terraform.io_workspaces.yaml
+++ b/config/crd/bases/app.terraform.io_workspaces.yaml
@@ -285,6 +285,9 @@ spec:
                 - repo_identifier
                 - token_id
                 type: object
+              workingDirectory:
+                description: Working directory within the module repository
+                type: string
             required:
             - organization
             - secretsMountPath

--- a/workspacehelper/tfc_org.go
+++ b/workspacehelper/tfc_org.go
@@ -105,6 +105,17 @@ func (t *TerraformCloudClient) SetTerraformVersion(workspace, terraformVersion s
 	return nil
 }
 
+func (t *TerraformCloudClient) SetWorkingDirectory(workspace, workingDirectory string) error {
+	wsUpdateOptions := tfc.WorkspaceUpdateOptions{
+		WorkingDirectory: &workingDirectory,
+	}
+	_, err := t.Client.Workspaces.Update(context.TODO(), t.Organization, workspace, wsUpdateOptions)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // getAgentPoolID uses AgentPoolName to lookup and return AgentPoolID
 func getAgentPoolID(specTFCAgentPoolName string, agentPools []*tfc.AgentPool) (*tfc.AgentPool, error) {
 	for _, agentPool := range agentPools {
@@ -198,6 +209,13 @@ func (t *TerraformCloudClient) CheckWorkspace(workspace string, instance *appv1a
 		}
 	}
 
+	if instance.Spec.WorkingDirectory != ws.WorkingDirectory {
+		err = t.SetWorkingDirectory(workspace, instance.Spec.WorkingDirectory)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if instance.Spec.AgentPoolID != ws.AgentPoolID {
 		err := t.updateAgentPoolID(instance, ws)
 		if err != nil {
@@ -246,6 +264,10 @@ func (t *TerraformCloudClient) CreateWorkspace(workspace string, instance *appv1
 		}
 		options.AgentPoolID = &agentPool.ID
 		options.ExecutionMode = tfc.String("agent")
+	}
+
+	if instance.Spec.WorkingDirectory != "" {
+		options.WorkingDirectory = &instance.Spec.WorkingDirectory
 	}
 
 	ws, err := t.Client.Workspaces.Create(context.TODO(), t.Organization, options)


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates or Closes #00000000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-k8s/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output:
<!--
Replace with relevant outputs or interfaces
-->
```
$ kubectl describe workspace

Name:         demo
Namespace:    default
Labels:       <none>
Annotations:  <none>
API Version:  app.terraform.io/v1alpha1
Kind:         Workspace
Metadata:
  Creation Timestamp:  2023-01-24T13:34:43Z
  Finalizers:
    finalizer.workspace.app.terraform.io
  Generation:  2
  Managed Fields:
    API Version:  app.terraform.io/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:module:
          .:
          f:source:
        f:organization:
        f:secretsMountPath:
        f:vcs:
          .:
          f:branch:
          f:repo_identifier:
          f:token_id:
        f:workingDirectory:
    Manager:      Go-http-client
    Operation:    Update
    Time:         2023-01-24T13:34:43Z
    API Version:  app.terraform.io/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .:
          v:"finalizer.workspace.app.terraform.io":
      f:spec:
        f:module:
          f:version:
        f:terraformVersion:
        f:variables:
      f:status:
        .:
        f:configVersionID:
        f:workspaceID:
    Manager:      terraform-k8s
    Operation:    Update
    Time:         2023-01-24T13:34:45Z
    API Version:  app.terraform.io/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        f:runID:
        f:runStatus:
    Manager:         terraform-k8s
    Operation:       Update
    Subresource:     status
    Time:            2023-01-24T13:34:49Z
  Resource Version:  32942851
  UID:               edb42054-3a99-45c3-b526-488c97e68592
Spec:
  Module:
    Source:            github.com/example-org/terraform-modules
    Version:
  Organization:        example-org
  Secrets Mount Path:  /tmp/secrets
  Terraform Version:
  Variables:
    Environment Variable:  false
    Hcl:                   false
    Key:                   environment
    Sensitive:             false
    Value:                 dev
    Environment Variable:  false
    Hcl:                   false
    Key:                   region
    Sensitive:             false
    Value:                 eu-west-1
    Environment Variable:  true
    Hcl:                   false
    Key:                   TFC_WORKLOAD_IDENTITY_AUDIENCE
    Sensitive:             false
    Value:                 example-org
  Vcs:
    Branch:           main
    repo_identifier:  example-org/terraform-modules
    token_id:         XX-XXXXXXXXXXX
  Working Directory:  /modules/demo-module

```
