### PR TITLE
Deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-# 📣 Terraform Cloud Operator v2 📣
+# terraform-k8s - DEPRECATED
 
-We are excited to announce the release of the latest version of the Terraform Cloud Operator for Kubernetes, now available at [hashicorp/terraform-cloud-operator](https://github.com/hashicorp/terraform-cloud-operator). This update introduces a more streamlined set of CRDs, along with new features such as Agent Pools, the capability to deploy and scale agents, Run Tasks, and Workspace Notifications. To learn more about these enhancements and to get started, please checkout our [announcement blog](https://www.hashicorp.com/blog/terraform-cloud-operator-v2-for-kubernetes-is-now-ga)
-  
-<a href="https://terraform.io">
-    <img src=".github/tf.png" alt="Terraform logo" title="Terraform" align="left" height="50" />
-</a>
+⚠️ **This repository is deprecated and no longer actively maintained.** ⚠️
+
+We strongly encourage users to migrate to the **[HCP Terraform Operator](https://github.com/hashicorp/hcp-terraform-operator)** for a more comprehensive, scalable, and supported solution.
+
+### Why this change?
+The HCP Terraform Operator provides advanced integration and ongoing support, offering a significantly improved experience for managing your HCP Terraform workflows with Kubernetes.
+
+### Migration Guide
+For details on migrating your existing setup, please refer to our comprehensive [Migration Guide](https://developer.hashicorp.com/terraform/cloud-docs/integrations/kubernetes/ops-v2-migration).
+
+---
 
 # Terraform Cloud Operator for Kubernetes (v1)
 


### PR DESCRIPTION
- Updated the README to announce the deprecation of the terraform-k8s repository.
- Added a clear notice encouraging users to migrate to the HCP Terraform Operator.
- Included links to the migration guide and the HCP Terraform Operator GitHub repository.